### PR TITLE
[FIX] estate: fix menus referring to non-existent actions T#71276

### DIFF
--- a/estate/views/estate_menus.xml
+++ b/estate/views/estate_menus.xml
@@ -7,8 +7,8 @@
         </menuitem>
 
         <menuitem id="estate_settings_menu" name="Settings">
-            <menuitem id="estate_property_type_menu" action="estate_property_type_setting" />
-            <menuitem id="estate_property_tag_menu" action="estate_property_tag_setting" />
+            <menuitem id="estate_property_type_menu" action="estate_property_type_action" />
+            <menuitem id="estate_property_tag_menu" action="estate_property_tag_action" />
         </menuitem>
     </menuitem>
 


### PR DESCRIPTION
There really nothing else here, just two lines of code.