### PR TITLE
[IMP] estate: add computed fields and onchange events T#71276

### DIFF
--- a/estate/models/estate_property.py
+++ b/estate/models/estate_property.py
@@ -1,4 +1,4 @@
-from odoo import fields, models
+from odoo import api, exceptions, fields, models
 
 
 class EstateProperty(models.Model):
@@ -45,3 +45,42 @@ class EstateProperty(models.Model):
     salesperson_id = fields.Many2one("res.users", default=lambda self: self.env.user, string="Salesman")
     tag_ids = fields.Many2many("estate.property.tag", string="Tags")
     offer_ids = fields.One2many("estate.property.offer", "property_id", string="Offers")
+    total_area = fields.Integer(compute="_compute_total_area", string="Total Area (sqm)")
+    best_price = fields.Float(compute="_compute_best_price", string="Best Offer")
+
+    @api.depends("living_area", "garden_area")
+    def _compute_total_area(self):
+        for record in self:
+            record.total_area = record.living_area + record.garden_area
+
+    @api.depends("offer_ids.price")
+    def _compute_best_price(self):
+        for record in self:
+            prices = record.offer_ids.mapped("price")
+            if prices:
+                record.best_price = max(prices)
+            else:
+                record.best_price = 0
+
+    @api.onchange("garden")
+    def _onchange_garden(self):
+        if self.garden:
+            self.garden_area = 10
+            self.garden_orientation = "north"
+        else:
+            self.garden_area = 0
+            self.garden_orientation = ""
+
+    def action_set_status_canceled(self):
+        for record in self:
+            if record.status == "sold":
+                raise exceptions.UserError("Sold properties cannot be canceled.")
+            record.status = "canceled"
+        return True
+
+    def action_set_status_sold(self):
+        for record in self:
+            if record.status == "canceled":
+                raise exceptions.UserError("Canceled properties cannot be sold.")
+            record.status = "sold"
+        return True

--- a/estate/models/estate_property_offer.py
+++ b/estate/models/estate_property_offer.py
@@ -1,4 +1,4 @@
-from odoo import fields, models
+from odoo import api, exceptions, fields, models
 
 
 class EstatePropertyOffer(models.Model):
@@ -15,3 +15,29 @@ class EstatePropertyOffer(models.Model):
     )
     partner_id = fields.Many2one("res.partner", required=True)
     property_id = fields.Many2one("estate.property", required=True)
+    validity = fields.Integer(default=7, string="Validity (days)")
+    date_deadline = fields.Date(compute="_compute_date_deadline", inverse="_inverse_date_deadline", string="Deadline")
+
+    @api.depends("validity")
+    def _compute_date_deadline(self):
+        for record in self:
+            if not record.create_date:
+                create_date = fields.Date.today()
+            else:
+                create_date = record.create_date.date()
+            record.date_deadline = fields.Date.add(create_date, days=record.validity)
+
+    def _inverse_date_deadline(self):
+        for record in self:
+            record.validity = (record.date_deadline - record.create_date.date()).days
+
+    def action_set_status_accepted(self):
+        for record in self:
+            if "accepted" in record.property_id.offer_ids.mapped("status"):
+                raise exceptions.UserError("Only one offer may be accepted.")
+            record.status = "accepted"
+            record.property_id.buyer_id = record.partner_id
+            record.property_id.selling_price = record.price
+
+    def action_set_status_refused(self):
+        self.write({"status": "refused"})

--- a/estate/views/estate_property_offer_views.xml
+++ b/estate/views/estate_property_offer_views.xml
@@ -8,6 +8,10 @@
             <tree>
                 <field name="price" />
                 <field name="partner_id" />
+                <field name="validity" />
+                <field name="date_deadline" />
+                <button name="action_set_status_accepted" string="Accept" type="object" icon="fa-check" />
+                <button name="action_set_status_refused" string="Refuse" type="object" icon="fa-times" />
                 <field name="status" />
             </tree>
         </field>
@@ -23,6 +27,8 @@
                         <group>
                             <field name="price" />
                             <field name="partner_id" />
+                            <field name="validity" />
+                            <field name="date_deadline" />
                             <field name="status" />
                         </group>
                     </group>

--- a/estate/views/estate_property_views.xml
+++ b/estate/views/estate_property_views.xml
@@ -24,6 +24,10 @@
         <field name="model">estate.property</field>
         <field name="arch" type="xml">
             <form>
+                <header>
+                    <button name="action_set_status_sold" type="object" string="Sold" />
+                    <button name="action_set_status_canceled" type="object" string="Cancel" />
+                </header>
                 <sheet>
                     <h1>
                         <field name="name" />
@@ -31,12 +35,14 @@
                     <field name="tag_ids" widget="many2many_tags" />
                     <group>
                         <group>
+                            <field name="status" />
                             <field name="property_type_id" />
                             <field name="postcode" />
                             <field name="date_availability" />
                         </group>
                         <group>
                             <field name="expected_price" />
+                            <field name="best_price" />
                             <field name="selling_price" />
                         </group>
                     </group>
@@ -51,6 +57,7 @@
                                 <field name="garden" />
                                 <field name="garden_area" />
                                 <field name="garden_orientation" />
+                                <field name="total_area" />
                             </group>
                         </page>
                         <page string="Offers">


### PR DESCRIPTION
## Summary 

- Add total_area computed field and include it in form view
- Add best_price computed field and include it in form view
- Add interdependent (computed and inverted) fields to model and display them
- Add onchange event to garden field
- Add actions to change status in EstateProperty model
- Compute selling_price and buyer_id fields based on EstatePropertyOffer model

## Screenshots

![image](https://user-images.githubusercontent.com/77471210/236527883-0288997e-7186-4c18-aa32-48bb92a44623.png)
*`total_area` and `best_price` computed fields*

![image](https://user-images.githubusercontent.com/77471210/236529040-b595a53c-01b0-48da-8f7a-b3350ba4a3eb.png)
![image](https://user-images.githubusercontent.com/77471210/236529135-4007c700-3f6f-4b82-85bc-422b13d66ca2.png)
*Interdependent `validity` and `date_deadline` fields*

![image](https://user-images.githubusercontent.com/77471210/236528369-d4c8c064-d81b-4570-94be-baa8bfa2993b.png)
![image](https://user-images.githubusercontent.com/77471210/236528414-36065358-1f82-4a7b-b128-d089dd9d97fa.png)
*Onchange for the `garden` field*

![image](https://user-images.githubusercontent.com/77471210/236529496-2f0f3019-bad0-4b2d-bf08-d26d304c2cd1.png)
![image](https://user-images.githubusercontent.com/77471210/236529565-77ba5919-eef6-41da-b9ef-42c4bd031d0a.png)
![image](https://user-images.githubusercontent.com/77471210/236529602-5eb233df-c0ec-4cc0-856e-fe314ad0a09a.png)
*Action buttons to change Property status in the header of the form in `EstateProperty` model*

![image](https://user-images.githubusercontent.com/77471210/236530337-7129c90f-9746-436b-b941-cdd04b0e0299.png)
![image](https://user-images.githubusercontent.com/77471210/236530471-347b946f-5b3a-4f74-81f0-cff2dafa4a2a.png)
*Compute `selling_price` and `buyer_id` fields based on `EstatePropertyOffer` model*