### PR TITLE
[IMP] estate: add constraints and further refine UI T#71276

### DIFF
--- a/estate/models/estate_property_offer.py
+++ b/estate/models/estate_property_offer.py
@@ -1,9 +1,11 @@
-from odoo import api, exceptions, fields, models
+from odoo import api, fields, models
+from odoo.exceptions import UserError
 
 
 class EstatePropertyOffer(models.Model):
     _name = "estate.property.offer"
     _description = "Estate Property Offer"
+    _order = "price desc"
 
     price = fields.Float()
     status = fields.Selection(
@@ -17,6 +19,11 @@ class EstatePropertyOffer(models.Model):
     property_id = fields.Many2one("estate.property", required=True)
     validity = fields.Integer(default=7, string="Validity (days)")
     date_deadline = fields.Date(compute="_compute_date_deadline", inverse="_inverse_date_deadline", string="Deadline")
+    property_type_id = fields.Many2one(related="property_id.property_type_id", store=True)
+
+    _sql_constraints = [
+        ("check_offer_price_positive", "CHECK (price > 0)", "The price offered must be greater than 0."),
+    ]
 
     @api.depends("validity")
     def _compute_date_deadline(self):
@@ -34,10 +41,11 @@ class EstatePropertyOffer(models.Model):
     def action_set_status_accepted(self):
         for record in self:
             if "accepted" in record.property_id.offer_ids.mapped("status"):
-                raise exceptions.UserError("Only one offer may be accepted.")
+                raise UserError("Only one offer may be accepted.")
             record.status = "accepted"
             record.property_id.buyer_id = record.partner_id
             record.property_id.selling_price = record.price
 
     def action_set_status_refused(self):
         self.write({"status": "refused"})
+        self.property_id.write({"selling_price": 0, "buyer_id": False})

--- a/estate/models/estate_property_tag.py
+++ b/estate/models/estate_property_tag.py
@@ -4,5 +4,15 @@ from odoo import fields, models
 class EstatePropertyTag(models.Model):
     _name = "estate.property.tag"
     _description = "Estate Property Tag"
+    _order = "name"
 
     name = fields.Char(required=True)
+    color = fields.Integer()
+
+    _sql_constraints = [
+        (
+            "name_unique",
+            "UNIQUE (name)",
+            "A property tag with the same name already exists.",
+        ),
+    ]

--- a/estate/models/estate_property_type.py
+++ b/estate/models/estate_property_type.py
@@ -1,8 +1,26 @@
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class EstatePropertyType(models.Model):
     _name = "estate.property.type"
     _description = "Estate Property Type"
+    _order = "name"
 
     name = fields.Char(required=True)
+    sequence = fields.Integer(default=1)
+    property_ids = fields.One2many("estate.property", "property_type_id", string="Properties")
+    offer_ids = fields.One2many("estate.property.offer", "property_type_id", string="Offers")
+    offer_count = fields.Integer(compute="_compute_offer_count")
+
+    _sql_constraints = [
+        (
+            "name_unique",
+            "UNIQUE (name)",
+            "A property type with the same name already exists.",
+        ),
+    ]
+
+    @api.depends("offer_ids")
+    def _compute_offer_count(self):
+        for record in self:
+            record.offer_count = len(record.offer_ids)

--- a/estate/views/estate_property_offer_views.xml
+++ b/estate/views/estate_property_offer_views.xml
@@ -5,14 +5,26 @@
         <field name="name">estate.property.offer.list</field>
         <field name="model">estate.property.offer</field>
         <field name="arch" type="xml">
-            <tree>
+            <tree decoration-danger="status=='refused'" decoration-success="status=='accepted'" editable="bottom">
                 <field name="price" />
                 <field name="partner_id" />
                 <field name="validity" />
                 <field name="date_deadline" />
-                <button name="action_set_status_accepted" string="Accept" type="object" icon="fa-check" />
-                <button name="action_set_status_refused" string="Refuse" type="object" icon="fa-times" />
-                <field name="status" />
+                <button
+                    name="action_set_status_accepted"
+                    icon="fa-check"
+                    string="Accept"
+                    type="object"
+                    attrs="{'invisible': ['|', ('status', '=', 'accepted'), ('status', '=', 'refused')]}"
+                />
+                <button
+                    name="action_set_status_refused"
+                    icon="fa-times"
+                    string="Refuse"
+                    type="object"
+                    attrs="{'invisible': ['|', ('status', '=', 'accepted'), ('status', '=', 'refused')]}"
+                />
+                <field name="status" invisible="1" />
             </tree>
         </field>
     </record>
@@ -35,6 +47,13 @@
                 </sheet>
             </form>
         </field>
+    </record>
+
+    <record id="estate_property_offer_action" model="ir.actions.act_window">
+        <field name="name">Property Offers</field>
+        <field name="res_model">estate.property.offer</field>
+        <field name="view_mode">tree,form</field>
+        <field name="domain">[("property_type_id", "=", active_id)]</field>
     </record>
 
 </odoo>

--- a/estate/views/estate_property_tag_views.xml
+++ b/estate/views/estate_property_tag_views.xml
@@ -5,7 +5,7 @@
         <field name="name">estate.property.tag.list</field>
         <field name="model">estate.property.tag</field>
         <field name="arch" type="xml">
-            <tree>
+            <tree editable="bottom">
                 <field name="name" />
             </tree>
         </field>

--- a/estate/views/estate_property_type_views.xml
+++ b/estate/views/estate_property_type_views.xml
@@ -7,6 +7,7 @@
         <field name="arch" type="xml">
             <tree>
                 <field name="name" />
+                <field name="sequence" widget="handle" />
             </tree>
         </field>
     </record>
@@ -17,9 +18,30 @@
         <field name="arch" type="xml">
             <form>
                 <sheet>
+                    <div class="oe_stat_button" name="button_box">
+                        <button
+                            name="estate.estate_property_offer_action"
+                            class="oe_stat_button"
+                            icon="fa-money"
+                            type="action"
+                        >
+                            <field name="offer_count" widget="statinfo" string="Offers" />
+                        </button>
+                    </div>
                     <h1>
                         <field name="name" />
                     </h1>
+                    <notebook>
+                        <page string="Properties">
+                            <field name="property_ids">
+                                <tree>
+                                    <field name="name" />
+                                    <field name="expected_price" />
+                                    <field name="status" />
+                                </tree>
+                            </field>
+                        </page>
+                    </notebook>
                 </sheet>
             </form>
         </field>

--- a/estate/views/estate_property_views.xml
+++ b/estate/views/estate_property_views.xml
@@ -5,16 +5,21 @@
         <field name="name">estate.property.list</field>
         <field name="model">estate.property</field>
         <field name="arch" type="xml">
-            <tree>
+            <tree
+                decoration-success="status in ['offer_received', 'offer_accepted']"
+                decoration-bf="status=='offer_accepted'"
+                decoration-muted="status=='sold'"
+            >
                 <field name="name" />
                 <field name="postcode" />
                 <field name="bedrooms" />
                 <field name="living_area" />
                 <field name="expected_price" />
                 <field name="selling_price" />
-                <field name="date_availability" />
+                <field name="date_availability" optional="hide" />
                 <field name="property_type_id" />
                 <field name="tag_ids" widget="many2many_tags" />
+                <field name="status" invisible="1" />
             </tree>
         </field>
     </record>
@@ -25,18 +30,33 @@
         <field name="arch" type="xml">
             <form>
                 <header>
-                    <button name="action_set_status_sold" type="object" string="Sold" />
-                    <button name="action_set_status_canceled" type="object" string="Cancel" />
+                    <button
+                        name="action_set_status_sold"
+                        string="Sold"
+                        type="object"
+                        attrs="{'invisible': ['|', ('status', '=', 'sold'), ('status', '=', 'canceled')]}"
+                    />
+                    <button
+                        name="action_set_status_canceled"
+                        type="object"
+                        string="Cancel"
+                        attrs="{'invisible': ['|', ('status', '=', 'sold'), ('status', '=', 'canceled')]}"
+                    />
+                    <field
+                        name="status"
+                        widget="statusbar"
+                        statusbar_visible="new,offer_received,offer_accepted,sold"
+                    />
                 </header>
                 <sheet>
                     <h1>
                         <field name="name" />
                     </h1>
-                    <field name="tag_ids" widget="many2many_tags" />
+                    <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" />
                     <group>
                         <group>
                             <field name="status" />
-                            <field name="property_type_id" />
+                            <field name="property_type_id" options="{'no_create': True}" />
                             <field name="postcode" />
                             <field name="date_availability" />
                         </group>
@@ -55,13 +75,16 @@
                                 <field name="facades" />
                                 <field name="garage" />
                                 <field name="garden" />
-                                <field name="garden_area" />
-                                <field name="garden_orientation" />
+                                <field name="garden_area" attrs="{'invisible': [('garden', '=', False)]}" />
+                                <field name="garden_orientation" attrs="{'invisible': [('garden', '=', False)]}" />
                                 <field name="total_area" />
                             </group>
                         </page>
                         <page string="Offers">
-                            <field name="offer_ids" />
+                            <field
+                                name="offer_ids"
+                                attrs="{'readonly': [('status', 'in', ['offer_accepted', 'sold', 'canceled'])]}"
+                            />
                         </page>
                         <page string="Other Info">
                             <group>
@@ -84,7 +107,7 @@
                 <field name="postcode" />
                 <field name="expected_price" />
                 <field name="bedrooms" />
-                <field name="living_area" />
+                <field name="living_area" filter_domain="[('living_area', '>=', self)]" />
                 <field name="facades" />
                 <filter
                     name="available"
@@ -101,6 +124,7 @@
         <field name="name">Properties</field>
         <field name="res_model">estate.property</field>
         <field name="view_mode">tree,form</field>
+        <field name="context">{'search_default_available': True}</field>
     </record>
 
 </odoo>


### PR DESCRIPTION
- Add required constraints to models
- Add constraints to validate offers expected and selling prices
- Add list of EstateProperties associated to PropertyTypes
- Add statusbar view to EstateProperty form
- Add db order to models
- Add sequence handler widget to PropertyTypes view
- Prevent creation/edition of PropertyTypes add color to PropetyTags
- Make the buttons in header vanish if property is sold or canceled
- Use attrs to hide fields, buttons, and make them readonly
- Make list views editable in-place
- Add decorations to entries based on fields' values
- Apply the **Available** filter associated to EstateProperty by default
- Add filter domain to the living_area field
- Add related field to PropertyOffer model
- Add computed field offer_count to PropertyType
- Add action and smart button linked to it filtering the view